### PR TITLE
hw1-cleancode

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -27,7 +27,7 @@ export default tseslint.config(
   },
   {
     rules: {
-      '@typescript-eslint/no-explicit-any': 'off',
+      '@typescript-eslint/no-explicit-any': 'warn',
       '@typescript-eslint/no-floating-promises': 'warn',
       '@typescript-eslint/no-unsafe-argument': 'warn',
     },

--- a/src/fetch/fetch.service.ts
+++ b/src/fetch/fetch.service.ts
@@ -5,7 +5,7 @@ import { WinstonLogger } from '../logger/logger.service';
 export class FetchService {
   constructor(private readonly logger: WinstonLogger) {}
 
-  async get<T = any>(url: string): Promise<T> {
+  async get<T>(url: string): Promise<T> {
     const res = await fetch(url);
 
     if (!res.ok) {

--- a/src/fetch/fetch.service.ts
+++ b/src/fetch/fetch.service.ts
@@ -5,7 +5,7 @@ import { WinstonLogger } from '../logger/logger.service';
 export class FetchService {
   constructor(private readonly logger: WinstonLogger) {}
 
-  async get<T>(url: string): Promise<T> {
+  async get<T = unknown>(url: string): Promise<T> {
     const res = await fetch(url);
 
     if (!res.ok) {

--- a/src/notification/notification.service.spec.ts
+++ b/src/notification/notification.service.spec.ts
@@ -92,7 +92,7 @@ describe('NotificationService', () => {
   describe('notifyHourly', () => {
     it('should call notifySubscribers with HOURLY', async () => {
       const spy = jest
-        .spyOn(service as any, 'notifySubscribers')
+        .spyOn(service, 'notifySubscribers' as keyof NotificationService)
         .mockImplementation();
       await service.notifyHourly();
       expect(spy).toHaveBeenCalledWith(NotificationFrequency.HOURLY);
@@ -102,7 +102,7 @@ describe('NotificationService', () => {
   describe('notifyDaily', () => {
     it('should call notifySubscribers with DAILY', async () => {
       const spy = jest
-        .spyOn(service as any, 'notifySubscribers')
+        .spyOn(service, 'notifySubscribers' as keyof NotificationService)
         .mockImplementation();
       await service.notifyDaily();
       expect(spy).toHaveBeenCalledWith(NotificationFrequency.DAILY);


### PR DESCRIPTION
**What was done:**
- ESLint: no-explicit-any set to warn
- FetchService.get: removed default any
- NotificationService tests: replaced any with precise types
